### PR TITLE
Update docker.py to pass XrdSecGSISRVNAMES into Singularity

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -42,6 +42,7 @@ for arg in sys.argv:
             dargs.append('--cap-add=SETUID')
             dargs.append('--cap-add=SETGID')
             dargs.append('--cap-add=SYS_CHROOT')
+            dargs.append('--env=SINGULARITYENV_XrdSecGSISRVNAMES=%s' % getfqdn())
     count += 1
 
 


### PR DESCRIPTION
Add SINGULARITYENV_XrdSecGSISRVNAMES  environmental variable to pass the FQDN to Singularity to allow Xrootd connections to the proxy within a Singularity container.